### PR TITLE
ABDERA-352 @Extension annotated List<> 

### DIFF
--- a/extensions/serializer/src/main/java/org/apache/abdera/ext/serializer/BaseSerializer.java
+++ b/extensions/serializer/src/main/java/org/apache/abdera/ext/serializer/BaseSerializer.java
@@ -92,16 +92,16 @@ public abstract class BaseSerializer extends Serializer {
             ObjectContext valueContext = new ObjectContext(value, source, accessor);
             Extension extension = valueContext.getAnnotation(Extension.class);
             boolean simple = extension != null ? extension.simple() : false;
-            Serializer ser = context.getSerializer(valueContext);
-            if (simple || ser == null) {
-                QName qname = getQName(accessor);
+            Serializer ser;
+            if (simple) {
+                final QName qname = getQName(accessor);
                 ser = new SimpleElementSerializer(qname);
             } else {
                 ser = context.getSerializer(valueContext);
-                if (ser == null) {
-                    QName qname = getQName(accessor);
-                    ser = new ExtensionSerializer(qname);
-                }
+            }
+            if (ser == null) {
+                final QName qname = getQName(accessor);
+                ser = new ExtensionSerializer(qname);
             }
             ser.serialize(value, valueContext, context);
         }

--- a/extensions/serializer/src/main/java/org/apache/abdera/ext/serializer/BaseSerializer.java
+++ b/extensions/serializer/src/main/java/org/apache/abdera/ext/serializer/BaseSerializer.java
@@ -86,24 +86,27 @@ public abstract class BaseSerializer extends Serializer {
                                    ObjectContext objectContext,
                                    SerializationContext context,
                                    Conventions conventions) {
-        AccessibleObject[] accessors = objectContext.getAccessors(Extension.class, conventions);
+        final AccessibleObject[] accessors = objectContext.getAccessors(Extension.class, conventions);
         for (AccessibleObject accessor : accessors) {
-            Object value = eval(accessor, source);
-            ObjectContext valueContext = new ObjectContext(value, source, accessor);
-            Extension extension = valueContext.getAnnotation(Extension.class);
-            boolean simple = extension != null ? extension.simple() : false;
-            Serializer ser;
-            if (simple) {
-                final QName qname = getQName(accessor);
-                ser = new SimpleElementSerializer(qname);
-            } else {
-                ser = context.getSerializer(valueContext);
+            final Object value = eval(accessor, source);
+            final Object[] values = toArray(value);
+            for (Object val : values) {
+                final ObjectContext valueContext = new ObjectContext(val, source, accessor);
+                final Extension extension = valueContext.getAnnotation(Extension.class);
+                final boolean simple = extension != null ? extension.simple() : false;
+                Serializer ser;
+                if (simple) {
+                    final QName qname = getQName(accessor);
+                    ser = new SimpleElementSerializer(qname);
+                } else {
+                    ser = context.getSerializer(valueContext);
+                }
+                if (ser == null) {
+                    final QName qname = getQName(accessor);
+                    ser = new ExtensionSerializer(qname);
+                }
+                ser.serialize(val, valueContext, context);
             }
-            if (ser == null) {
-                final QName qname = getQName(accessor);
-                ser = new ExtensionSerializer(qname);
-            }
-            ser.serialize(value, valueContext, context);
         }
     }
 

--- a/extensions/serializer/src/main/java/org/apache/abdera/ext/serializer/BaseSerializer.java
+++ b/extensions/serializer/src/main/java/org/apache/abdera/ext/serializer/BaseSerializer.java
@@ -93,16 +93,14 @@ public abstract class BaseSerializer extends Serializer {
             Extension extension = valueContext.getAnnotation(Extension.class);
             boolean simple = extension != null ? extension.simple() : false;
             Serializer ser = context.getSerializer(valueContext);
-            if (ser == null) {
-                if (simple) {
+            if (simple || ser == null) {
+                QName qname = getQName(accessor);
+                ser = new SimpleElementSerializer(qname);
+            } else {
+                ser = context.getSerializer(valueContext);
+                if (ser == null) {
                     QName qname = getQName(accessor);
-                    ser = new SimpleElementSerializer(qname);
-                } else {
-                    ser = context.getSerializer(valueContext);
-                    if (ser == null) {
-                        QName qname = getQName(accessor);
-                        ser = new ExtensionSerializer(qname);
-                    }
+                    ser = new ExtensionSerializer(qname);
                 }
             }
             ser.serialize(value, valueContext, context);
@@ -249,7 +247,7 @@ public abstract class BaseSerializer extends Serializer {
     protected static QName getQName(Extension extension) {
         QName qname = null;
         if (extension != null) {
-            if (isUndefined(extension.prefix()) && isUndefined(extension.ns()) && isUndefined(extension.name())) {
+            if (!isUndefined(extension.prefix()) && !isUndefined(extension.ns()) && !isUndefined(extension.name())) {
                 qname = new QName(extension.ns(), extension.name(), extension.prefix());
             } else if (isUndefined(extension.prefix()) && !isUndefined(extension.ns())
                 && !isUndefined(extension.name())) {

--- a/extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/AbderaTestHelper.java
+++ b/extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/AbderaTestHelper.java
@@ -1,0 +1,18 @@
+package org.apache.abdera.test.ext.serializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.apache.abdera.Abdera;
+import org.apache.abdera.model.Document;
+import org.apache.abdera.model.Element;
+
+public final class AbderaTestHelper {
+
+    public static final <T extends Element> T deserialize(final ByteArrayOutputStream serialized) {
+        final ByteArrayInputStream in = new ByteArrayInputStream(serialized.toByteArray());
+        final Document<T> doc = Abdera.getInstance().getParser().parse(in);
+        return doc.getRoot();
+    }
+
+}

--- a/extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/ExtensionAnnotationTest.java
+++ b/extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/ExtensionAnnotationTest.java
@@ -1,0 +1,198 @@
+package org.apache.abdera.test.ext.serializer;
+
+import java.io.ByteArrayOutputStream;
+import javax.xml.namespace.QName;
+
+import org.apache.abdera.Abdera;
+import org.apache.abdera.ext.serializer.ConventionSerializationContext;
+import org.apache.abdera.ext.serializer.annotation.Entry;
+import org.apache.abdera.ext.serializer.annotation.Extension;
+import org.apache.abdera.model.Element;
+import org.apache.abdera.model.ExtensibleElement;
+import org.apache.abdera.writer.StreamWriter;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public final class ExtensionAnnotationTest {
+
+    private static final String PREFIX = "foo";
+
+    private static final String NS = "http://example.org/foo";
+
+    private static final String EXT_NAME = "ext";
+
+    private static final QName EXT_QNAME = new QName(NS, EXT_NAME, PREFIX);
+
+    /**
+     * Expected serialized result:
+     * <?xml version='1.0'?>
+     * <entry xmlns="http://www.w3.org/2005/Atom">
+     *   <foo:ext xmlns:s="http://example.org/foo">
+     *     foo
+     *   </foo:ext>
+     * </entry>
+     */
+    @Entry
+    public static final class EntryWithSimpleExtension {
+
+        private final String value;
+
+        public EntryWithSimpleExtension(final String value) {
+            this.value = value;
+        }
+
+        @Extension(prefix = PREFIX, ns = NS, name = EXT_NAME, simple = true)
+        public String getSimpleExtension() {
+            return value;
+        }
+
+    }
+
+    /**
+     * Expected serialized result:
+     * <?xml version='1.0'?>
+     * <entry xmlns="http://www.w3.org/2005/Atom">
+     *   <foo:ext xmlns:s="http://example.org/foo">
+     *     <foo:ext xmlns:s="http://example.org/foo">
+     *       foo
+     *     </foo:ext>
+     *   </foo:ext>
+     * </entry>
+     */
+    @Entry
+    public static final class EntryWithExtensionNestingSimpleExtension {
+
+        @Extension(prefix = PREFIX, ns = NS, name = EXT_NAME)
+        public ExtensionNestingSimpleExtension getExtension() {
+            return new ExtensionNestingSimpleExtension("foo");
+        }
+
+    }
+
+    public static final class ExtensionNestingSimpleExtension {
+
+        private final String value;
+
+        public ExtensionNestingSimpleExtension(final String value) {
+            this.value = value;
+        }
+
+        @Extension(prefix = PREFIX, ns = NS, name = EXT_NAME, simple = true)
+        public String getNestedExtension() {
+            return value;
+        }
+
+    }
+
+    /**
+     * Expected serialized result:
+     * <?xml version='1.0'?>
+     * <entry xmlns="http://www.w3.org/2005/Atom">
+     *   <foo:ext xmlns:s="http://example.org/foo">
+     *     <foo:ext xmlns:s="http://example.org/foo">
+     *       <foo:ext xmlns:s="http://example.org/foo">
+     *         foo
+     *       </foo:ext>
+     *     </foo:ext>
+     *   </foo:ext>
+     * </entry>
+     */
+    @Entry
+    public static final class EntryWithExtensionNestingExtensionNestingSimpleExtension {
+
+        @Extension(prefix = PREFIX, ns = NS, name = EXT_NAME)
+        public ExtensionNestingExtensionNestingSimpleExtension getExtension() {
+            return new ExtensionNestingExtensionNestingSimpleExtension("foo");
+        }
+
+    }
+
+    public static final class ExtensionNestingExtensionNestingSimpleExtension {
+
+        private final String value;
+
+        public ExtensionNestingExtensionNestingSimpleExtension(final String value) {
+            this.value = value;
+        }
+
+        @Extension(prefix = PREFIX, ns = NS, name = EXT_NAME)
+        public ExtensionNestingSimpleExtension getExtensionNestingSimpleExtension() {
+            return new ExtensionNestingSimpleExtension(value);
+        }
+
+    }
+
+    private final Abdera abdera = Abdera.getInstance();
+
+    @Test
+    public void shouldGenerateSimpleExtension() {
+        // given
+        final EntryWithSimpleExtension source = new EntryWithSimpleExtension("foo");
+
+        // when
+        final StreamWriter streamWriter = abdera.newStreamWriter();
+        final ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+        streamWriter.setOutputStream(serialized).setAutoIndent(true);
+        final ConventionSerializationContext context = new ConventionSerializationContext(streamWriter);
+        streamWriter.startDocument();
+        context.serialize(source);
+        streamWriter.endDocument();
+
+        // then
+        final org.apache.abdera.model.Entry entry = AbderaTestHelper.deserialize(serialized);
+        final ExtensibleElement extension = entry.getExtension(EXT_QNAME);
+        assertNotNull(extension);
+        assertEquals("foo", extension.getText().trim());
+    }
+
+    @Test
+    public void shouldGenerateExtensionNestingSimpleExtension() {
+        // given
+        final EntryWithExtensionNestingSimpleExtension source = new EntryWithExtensionNestingSimpleExtension();
+
+        // when
+        final StreamWriter streamWriter = abdera.newStreamWriter();
+        final ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+        streamWriter.setOutputStream(serialized).setAutoIndent(true);
+        final ConventionSerializationContext context = new ConventionSerializationContext(streamWriter);
+        streamWriter.startDocument();
+        context.serialize(source);
+        streamWriter.endDocument();
+
+        // then
+        final org.apache.abdera.model.Entry entry = AbderaTestHelper.deserialize(serialized);
+        final ExtensibleElement extension = entry.getExtension(EXT_QNAME);
+        assertNotNull(extension);
+        final Element simple = extension.getExtension(EXT_QNAME);
+        assertNotNull(simple);
+        assertEquals("foo", simple.getText().trim());
+    }
+
+    @Test
+    public void shouldGenerateExtensionNestingExtensionNestingSimpleExtension() {
+        // given
+        final EntryWithExtensionNestingExtensionNestingSimpleExtension source = 
+                new EntryWithExtensionNestingExtensionNestingSimpleExtension();
+
+        // when
+        final StreamWriter streamWriter = abdera.newStreamWriter();
+        final ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+        streamWriter.setOutputStream(serialized).setAutoIndent(true);
+        final ConventionSerializationContext context = new ConventionSerializationContext(streamWriter);
+        streamWriter.startDocument();
+        context.serialize(source);
+        streamWriter.endDocument();
+
+        // then
+        final org.apache.abdera.model.Entry entry = AbderaTestHelper.deserialize(serialized);
+        final ExtensibleElement extension = entry.getExtension(EXT_QNAME);
+        assertNotNull(extension);
+        final ExtensibleElement nested = extension.getExtension(EXT_QNAME);
+        assertNotNull(nested);
+        final Element simple = nested.getExtension(EXT_QNAME);
+        assertNotNull(simple);
+        assertEquals("foo", simple.getText().trim());
+    }
+}

--- a/extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/SerializerTest.java
+++ b/extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/SerializerTest.java
@@ -18,19 +18,15 @@
 package org.apache.abdera.test.ext.serializer;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Calendar;
 import java.util.Date;
 
-import javax.xml.namespace.QName;
-
 import org.apache.abdera.Abdera;
 import org.apache.abdera.ext.serializer.ConventionSerializationContext;
 import org.apache.abdera.ext.serializer.annotation.Author;
-import org.apache.abdera.ext.serializer.annotation.Extension;
 import org.apache.abdera.ext.serializer.annotation.ID;
 import org.apache.abdera.ext.serializer.annotation.Link;
 import org.apache.abdera.ext.serializer.annotation.Published;
@@ -40,7 +36,6 @@ import org.apache.abdera.ext.serializer.annotation.Updated;
 import org.apache.abdera.ext.serializer.impl.EntrySerializer;
 import org.apache.abdera.model.Document;
 import org.apache.abdera.model.Entry;
-import org.apache.abdera.model.ExtensibleElement;
 import org.apache.abdera.writer.StreamWriter;
 import org.junit.Test;
 
@@ -124,69 +119,6 @@ public class SerializerTest {
         assertEquals("James", entry.getAuthor().getName());
         assertEquals("this is the summary", entry.getSummary());
         assertEquals("http://example.org/foo", entry.getAlternateLink().getResolvedHref().toString());
-
-        final ExtensibleElement simpleExtension = entry.getExtension(SimpleExtensionQName.INSTANCE);
-        assertNotNull(simpleExtension);
-        assertEquals("baz", simpleExtension.getText());
-
-        final ExtensibleElement complexExtension = entry.getExtension(ComplexExtensionQName.INSTANCE);
-        assertNotNull(complexExtension);
-        final ExtensibleElement nestedSimpleExtension = complexExtension.getExtension(SimpleExtensionQName.INSTANCE);
-        assertNotNull(nestedSimpleExtension);
-        assertEquals("baz", nestedSimpleExtension.getText());
-
-        final ExtensibleElement moreComplexExtension = entry.getExtension(MoreComplexExtensionQName.INSTANCE);
-        assertNotNull(moreComplexExtension);
-        final ExtensibleElement nestedComplexExtension = moreComplexExtension.getExtension(ComplexExtensionQName.INSTANCE);
-        assertNotNull(nestedComplexExtension);
-        final ExtensibleElement deepNestedSimpleExtension = nestedComplexExtension.getExtension(SimpleExtensionQName.INSTANCE);
-        assertNotNull(deepNestedSimpleExtension);
-        assertEquals("baz", deepNestedSimpleExtension.getText());
-    }
-
-    private static final class SimpleExtensionQName extends QName {
-
-        public static final String NS = "http://example.org/simple";
-
-        public static final String NAME = "foo";
-
-        public static final String PREFIX = "simple";
-
-        public static final QName INSTANCE = new SimpleExtensionQName();
-
-        private SimpleExtensionQName() {
-            super(NS, NAME, PREFIX);
-        }
-    }
-
-    private static final class ComplexExtensionQName extends QName {
-
-        public static final String NS = "http://example.org/complex";
-
-        public static final String NAME = "foo";
-
-        public static final String PREFIX = "complex";
-
-        public static final QName INSTANCE = new ComplexExtensionQName();
-
-        private ComplexExtensionQName() {
-            super(NS, NAME, PREFIX);
-        }
-    }
-
-    private static final class MoreComplexExtensionQName extends QName {
-
-        public static final String NS = "http://example.org/morecomplex";
-
-        public static final String NAME = "foo";
-
-        public static final String PREFIX = "morecomplex";
-
-        public static final QName INSTANCE = new MoreComplexExtensionQName();
-
-        private MoreComplexExtensionQName() {
-            super(NS, NAME, PREFIX);
-        }
     }
 
     @org.apache.abdera.ext.serializer.annotation.Entry
@@ -221,40 +153,5 @@ public class SerializerTest {
         public String getUri() {
             return "http://example.org/foo";
         }
-
-        @Extension(ns = SimpleExtensionQName.NS, name = SimpleExtensionQName.NAME, prefix = SimpleExtensionQName.PREFIX, simple = true)
-        public String getSimpleExtension() {
-            return "baz";
-        }
-
-        @Extension(ns = ComplexExtensionQName.NS, name = ComplexExtensionQName.NAME, prefix = ComplexExtensionQName.PREFIX)
-        public ComplexExtension getComplexExtension() {
-            return new ComplexExtension();
-        }
-
-        @Extension(ns = MoreComplexExtensionQName.NS, name = MoreComplexExtensionQName.NAME, prefix = MoreComplexExtensionQName.PREFIX)
-        public MoreComplexExtension getMoreComplexExtension() {
-            return new MoreComplexExtension();
-        }
-
     }
-
-    public static class ComplexExtension {
-
-        @Extension(ns = SimpleExtensionQName.NS, name = SimpleExtensionQName.NAME, prefix = SimpleExtensionQName.PREFIX, simple = true)
-        public String getSimpleExtension() {
-            return "baz";
-        }
-
-    }
-
-    public static class MoreComplexExtension {
-
-        @Extension(ns = ComplexExtensionQName.NS, name = ComplexExtensionQName.NAME, prefix = ComplexExtensionQName.PREFIX)
-        public ComplexExtension getComplexExtension() {
-            return new ComplexExtension();
-        }
-
-    }
-
 }

--- a/extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/TestSuite.java
+++ b/extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/TestSuite.java
@@ -25,5 +25,6 @@ public class TestSuite {
         JUnitCore runner = new JUnitCore();
         runner.addListener(new TextListener(System.out));
         runner.run(SerializerTest.class);
+        runner.run(ExtensionAnnotationTest.class);
     }
 }


### PR DESCRIPTION
Used the same system in BaseSerializer.writeExtensions() as in BaseSerializer.writeElements() with calling BaseSerializer.toArray() and looping through the values.

@Extension annotated List<> of object now get serialized into multiple elements.
See extensions/serializer/src/test/java/org/apache/abdera/test/ext/serializer/ExtensionAnnotationTest.java for details.
